### PR TITLE
Add ruby3 gc metrics 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Or install it yourself as:
 ## Metrics
 
 | Metric                                    | Description                                                                                               |
-| ----------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+|-------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | `count`                                   | Count of all GCs                                                                                          |
+| `time`                                    | The total time spent in garbage collections (ruby 3+)                                                     |
 | `minor_gc_count`                          | Count of minor GCs                                                                                        |
 | `major_gc_count`                          | Count of major GCs                                                                                        |
 | `heap_allocated_pages`                    | Total number of pages allocated for the heap                                                              |
@@ -48,6 +49,8 @@ Or install it yourself as:
 | `oldmalloc_increase_bytes`                | Total bytes allocated to old objects                                                                      |
 | `oldmalloc_increase_bytes_limit`          | Bytes limit that will trigger garbage collection of old objects                                           |
 | `compact_count`                           | Count of all GC compactions                                                                               |
+| `read_barrier_faults`                     | The total number of times the read barrier was triggered during compaction (ruby 3+)                      |
+| `total_moved_objects`                     | The total number of objects compaction has moved (ruby 3+)                                                |
 
 ## Development
 

--- a/lib/yabeda/gc.rb
+++ b/lib/yabeda/gc.rb
@@ -44,6 +44,12 @@ module Yabeda
       gauge :oldmalloc_increase_bytes_limit, tags: [],
                                              comment: "Bytes limit that will trigger garbage collection of old objects"
 
+      if RUBY_VERSION >= '3.0'
+        gauge :time, tags: [], comment: "The total time spent in garbage collections"
+        gauge :read_barrier_faults, tags: [], comment: "The total number of times the read barrier was triggered during compaction"
+        gauge :total_moved_objects, tags: [], comment: "The total number of objects compaction has moved"
+      end
+
       collect do
         stats = ::GC.stat
 

--- a/lib/yabeda/gc.rb
+++ b/lib/yabeda/gc.rb
@@ -44,7 +44,7 @@ module Yabeda
       gauge :oldmalloc_increase_bytes_limit, tags: [],
                                              comment: "Bytes limit that will trigger garbage collection of old objects"
 
-      if RUBY_VERSION >= '3.0'
+      if RUBY_VERSION >= "3.0"
         gauge :time, tags: [], comment: "The total time spent in garbage collections"
         gauge :read_barrier_faults, tags: [], comment: "The total number of times the read barrier was triggered during compaction"
         gauge :total_moved_objects, tags: [], comment: "The total number of objects compaction has moved"

--- a/lib/yabeda/gc/version.rb
+++ b/lib/yabeda/gc/version.rb
@@ -2,6 +2,6 @@
 
 module Yabeda
   module GC
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/spec/yabeda/gc_spec.rb
+++ b/spec/yabeda/gc_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Yabeda::GC do
   before do
-    ::GC.stat.keys.each do |method_name|
+    ::GC.stat.each_key do |method_name|
       Yabeda.gc.__send__(method_name).values.clear
     end
   end
@@ -43,7 +43,7 @@ RSpec.describe Yabeda::GC do
     )
   end
 
-  if RUBY_VERSION >= '3.0'
+  if RUBY_VERSION >= "3.0"
     it "tracks ruby3 metrics for GC" do
       Yabeda.collectors.each(&:call)
 
@@ -58,7 +58,7 @@ RSpec.describe Yabeda::GC do
   def summary
     result = {}
 
-    ::GC.stat.keys.each do |method_name|
+    ::GC.stat.each_key do |method_name|
       metric = Yabeda.gc.__send__(method_name)
       result[metric.name] = metric.values
     end


### PR DESCRIPTION
Current version raises error if used with ruby 3.
Reason: three GC.stat metrics are missing: time, total_moved_objects, read_barrier_faults